### PR TITLE
Add item regarding structured logging and custom spans

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,9 @@
 - [ ] *Planned deployment*
   - Package version bumped
   - Breaking changes being rolled out to all impacted areas
+- [ ] Considered *monitoring* and *observability*
+  - Appropriate logging added using `@seccl/logger`
+  - Using [structured logging](https://newrelic.com/blog/how-to-relic/structured-logging) instead of string interpolation
 - [ ] Considered *architecture*
   - ADR approved where required
   - [Seccl Architecture](https://app.mural.co/t/secclsipp0609/m/secclsipp0609/1684748358632/0f1a5c38302fe4e032279d9c502c7e47187ad0ff?sender=u2bda92941015f4707d213946) followed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@
 - [ ] Considered *monitoring* and *observability*
   - Appropriate logging added using `@seccl/logger`
   - Using [structured logging](https://newrelic.com/blog/how-to-relic/structured-logging) instead of string interpolation
+  - External service calls are captured in a [span](https://github.com/SecclTech/logger?tab=readme-ov-file#telemetry-1) with adequate attributes
 - [ ] Considered *architecture*
   - ADR approved where required
   - [Seccl Architecture](https://app.mural.co/t/secclsipp0609/m/secclsipp0609/1684748358632/0f1a5c38302fe4e032279d9c502c7e47187ad0ff?sender=u2bda92941015f4707d213946) followed


### PR DESCRIPTION
### Context / Why are we making a change?
We need an additional reminder to help ensure that:

1. Engineers have considered adding logging to assist with monitoring, observability and debugging the system in production.
2. Engineers are using the correct format to add logging
3. Engineers are using `@seccl/logger` and not `console.log`

### Description / What has been changed?
- Added an additional item to ensure that logging has been considered

### Other / What else might be useful to know?
It is very important that engineers use structured logging and not string interpolation so that we can easily perform activities like creating DataDog dashboards and alerts, or easily perform searches on logs without having to use complex regex expressions.

### Checks to be considered:
- [X] Performed a *self-review* of the code